### PR TITLE
EBS Root Volume Termination

### DIFF
--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -633,6 +633,10 @@ spec:
               description: RootVolumeOptimization enables EBS optimization for an
                 instance
               type: boolean
+            rootVolumeRetainOnTermination:
+              description: RootVolumeRetainOnTermination prevents root volume from
+                being deleted after instance termination
+              type: boolean
             rootVolumeSize:
               description: RootVolumeSize is the size of the EBS root volume to use,
                 in GB
@@ -713,6 +717,10 @@ spec:
                       in aws)
                     format: int64
                     type: integer
+                  retainOnTermination:
+                    description: RetainOnTermination prevents volume from being deleted
+                      after instance termination
+                    type: boolean
                   size:
                     description: Size is the size of the volume in GB
                     format: int64

--- a/pkg/apis/kops/instancegroup.go
+++ b/pkg/apis/kops/instancegroup.go
@@ -106,6 +106,8 @@ type InstanceGroupSpec struct {
 	RootVolumeIops *int32 `json:"rootVolumeIops,omitempty"`
 	// RootVolumeOptimization enables EBS optimization for an instance
 	RootVolumeOptimization *bool `json:"rootVolumeOptimization,omitempty"`
+	// RootVolumeRetainOnTermination prevents root volume from being deleted after instance termination
+	RootVolumeRetainOnTermination *bool `json:"rootVolumeRetainOnTermination,omitempty"`
 	// Volumes is a collection of additional volumes to create for instances within this InstanceGroup
 	Volumes []*VolumeSpec `json:"volumes,omitempty"`
 	// VolumeMounts a collection of volume mounts
@@ -208,6 +210,8 @@ type VolumeSpec struct {
 	Size int64 `json:"size,omitempty"`
 	// Type is the type of volume to create and is cloud specific
 	Type string `json:"type,omitempty"`
+	// RetainOnTermination prevents volume from being deleted after instance termination
+	RetainOnTermination *bool `json:"retainOnTermination,omitempty"`
 }
 
 // VolumeMountSpec defines the specification for mounting a device

--- a/pkg/apis/kops/v1alpha1/instancegroup.go
+++ b/pkg/apis/kops/v1alpha1/instancegroup.go
@@ -94,6 +94,8 @@ type InstanceGroupSpec struct {
 	RootVolumeIops *int32 `json:"rootVolumeIops,omitempty"`
 	// RootVolumeOptimization enables EBS optimization for an instance
 	RootVolumeOptimization *bool `json:"rootVolumeOptimization,omitempty"`
+	// RootVolumeRetainOnTermination prevents root volume from being deleted after instance termination
+	RootVolumeRetainOnTermination *bool `json:"rootVolumeRetainOnTermination,omitempty"`
 	// Volumes is a collection of additional volumes to create for instances within this InstanceGroup
 	Volumes []*VolumeSpec `json:"volumes,omitempty"`
 	// VolumeMounts a collection of volume mounts
@@ -203,6 +205,8 @@ type VolumeSpec struct {
 	Size int64 `json:"size,omitempty"`
 	// Type is the type of volume to create and is cloud specific
 	Type string `json:"type,omitempty"`
+	// RetainOnTermination prevents volume from being deleted after instance termination
+	RetainOnTermination *bool `json:"retainOnTermination,omitempty"`
 }
 
 // VolumeMountSpec defines the specification for mounting a device

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -2875,6 +2875,7 @@ func autoConvert_v1alpha1_InstanceGroupSpec_To_kops_InstanceGroupSpec(in *Instan
 	out.RootVolumeType = in.RootVolumeType
 	out.RootVolumeIops = in.RootVolumeIops
 	out.RootVolumeOptimization = in.RootVolumeOptimization
+	out.RootVolumeRetainOnTermination = in.RootVolumeRetainOnTermination
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes
 		*out = make([]*kops.VolumeSpec, len(*in))
@@ -2995,6 +2996,7 @@ func autoConvert_kops_InstanceGroupSpec_To_v1alpha1_InstanceGroupSpec(in *kops.I
 	out.RootVolumeType = in.RootVolumeType
 	out.RootVolumeIops = in.RootVolumeIops
 	out.RootVolumeOptimization = in.RootVolumeOptimization
+	out.RootVolumeRetainOnTermination = in.RootVolumeRetainOnTermination
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes
 		*out = make([]*VolumeSpec, len(*in))
@@ -4716,6 +4718,7 @@ func autoConvert_v1alpha1_VolumeSpec_To_kops_VolumeSpec(in *VolumeSpec, out *kop
 	out.Iops = in.Iops
 	out.Size = in.Size
 	out.Type = in.Type
+	out.RetainOnTermination = in.RetainOnTermination
 	return nil
 }
 
@@ -4730,6 +4733,7 @@ func autoConvert_kops_VolumeSpec_To_v1alpha1_VolumeSpec(in *kops.VolumeSpec, out
 	out.Iops = in.Iops
 	out.Size = in.Size
 	out.Type = in.Type
+	out.RetainOnTermination = in.RetainOnTermination
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.deepcopy.go
@@ -1545,6 +1545,11 @@ func (in *InstanceGroupSpec) DeepCopyInto(out *InstanceGroupSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.RootVolumeRetainOnTermination != nil {
+		in, out := &in.RootVolumeRetainOnTermination, &out.RootVolumeRetainOnTermination
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes
 		*out = make([]*VolumeSpec, len(*in))
@@ -3302,6 +3307,11 @@ func (in *VolumeSpec) DeepCopyInto(out *VolumeSpec) {
 	if in.Iops != nil {
 		in, out := &in.Iops, &out.Iops
 		*out = new(int64)
+		**out = **in
+	}
+	if in.RetainOnTermination != nil {
+		in, out := &in.RetainOnTermination, &out.RetainOnTermination
+		*out = new(bool)
 		**out = **in
 	}
 	return

--- a/pkg/apis/kops/v1alpha2/instancegroup.go
+++ b/pkg/apis/kops/v1alpha2/instancegroup.go
@@ -99,6 +99,8 @@ type InstanceGroupSpec struct {
 	RootVolumeIops *int32 `json:"rootVolumeIops,omitempty"`
 	// RootVolumeOptimization enables EBS optimization for an instance
 	RootVolumeOptimization *bool `json:"rootVolumeOptimization,omitempty"`
+	// RootVolumeRetainOnTermination prevents root volume from being deleted after instance termination
+	RootVolumeRetainOnTermination *bool `json:"rootVolumeRetainOnTermination,omitempty"`
 	// Volumes is a collection of additional volumes to create for instances within this InstanceGroup
 	Volumes []*VolumeSpec `json:"volumes,omitempty"`
 	// VolumeMounts a collection of volume mounts
@@ -202,6 +204,8 @@ type VolumeSpec struct {
 	Size int64 `json:"size,omitempty"`
 	// Type is the type of volume to create and is cloud specific
 	Type string `json:"type,omitempty"`
+	// RetainOnTermination prevents volume from being deleted after instance termination
+	RetainOnTermination *bool `json:"retainOnTermination,omitempty"`
 }
 
 // VolumeMountSpec defines the specification for mounting a device

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -2992,6 +2992,7 @@ func autoConvert_v1alpha2_InstanceGroupSpec_To_kops_InstanceGroupSpec(in *Instan
 	out.RootVolumeType = in.RootVolumeType
 	out.RootVolumeIops = in.RootVolumeIops
 	out.RootVolumeOptimization = in.RootVolumeOptimization
+	out.RootVolumeRetainOnTermination = in.RootVolumeRetainOnTermination
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes
 		*out = make([]*kops.VolumeSpec, len(*in))
@@ -3118,6 +3119,7 @@ func autoConvert_kops_InstanceGroupSpec_To_v1alpha2_InstanceGroupSpec(in *kops.I
 	out.RootVolumeType = in.RootVolumeType
 	out.RootVolumeIops = in.RootVolumeIops
 	out.RootVolumeOptimization = in.RootVolumeOptimization
+	out.RootVolumeRetainOnTermination = in.RootVolumeRetainOnTermination
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes
 		*out = make([]*VolumeSpec, len(*in))
@@ -5044,6 +5046,7 @@ func autoConvert_v1alpha2_VolumeSpec_To_kops_VolumeSpec(in *VolumeSpec, out *kop
 	out.Iops = in.Iops
 	out.Size = in.Size
 	out.Type = in.Type
+	out.RetainOnTermination = in.RetainOnTermination
 	return nil
 }
 
@@ -5058,6 +5061,7 @@ func autoConvert_kops_VolumeSpec_To_v1alpha2_VolumeSpec(in *kops.VolumeSpec, out
 	out.Iops = in.Iops
 	out.Size = in.Size
 	out.Type = in.Type
+	out.RetainOnTermination = in.RetainOnTermination
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -1502,6 +1502,11 @@ func (in *InstanceGroupSpec) DeepCopyInto(out *InstanceGroupSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.RootVolumeRetainOnTermination != nil {
+		in, out := &in.RootVolumeRetainOnTermination, &out.RootVolumeRetainOnTermination
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes
 		*out = make([]*VolumeSpec, len(*in))
@@ -3373,6 +3378,11 @@ func (in *VolumeSpec) DeepCopyInto(out *VolumeSpec) {
 	if in.Iops != nil {
 		in, out := &in.Iops, &out.Iops
 		*out = new(int64)
+		**out = **in
+	}
+	if in.RetainOnTermination != nil {
+		in, out := &in.RetainOnTermination, &out.RetainOnTermination
+		*out = new(bool)
 		**out = **in
 	}
 	return

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -1668,6 +1668,11 @@ func (in *InstanceGroupSpec) DeepCopyInto(out *InstanceGroupSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.RootVolumeRetainOnTermination != nil {
+		in, out := &in.RootVolumeRetainOnTermination, &out.RootVolumeRetainOnTermination
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes
 		*out = make([]*VolumeSpec, len(*in))
@@ -3587,6 +3592,11 @@ func (in *VolumeSpec) DeepCopyInto(out *VolumeSpec) {
 	if in.Iops != nil {
 		in, out := &in.Iops, &out.Iops
 		*out = new(int64)
+		**out = **in
+	}
+	if in.RetainOnTermination != nil {
+		in, out := &in.RetainOnTermination, &out.RetainOnTermination
+		*out = new(bool)
 		**out = **in
 	}
 	return

--- a/upup/pkg/fi/cloudup/awstasks/launchconfiguration.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchconfiguration.go
@@ -75,6 +75,8 @@ type LaunchConfiguration struct {
 	RootVolumeOptimization *bool
 	// RootVolumeSize is the size of the EBS root volume to use, in GB
 	RootVolumeSize *int64
+	// RootVolumeTermination defines wether to keep EBS root volume on termination
+	RootVolumeTermination *bool
 	// RootVolumeType is the type of the EBS root volume to use (e.g. gp2)
 	RootVolumeType *string
 	// SSHKey is the ssh key for the instances
@@ -197,6 +199,7 @@ func (e *LaunchConfiguration) Find(c *fi.Context) (*LaunchConfiguration, error) 
 			actual.RootVolumeSize = b.Ebs.VolumeSize
 			actual.RootVolumeType = b.Ebs.VolumeType
 			actual.RootVolumeIops = b.Ebs.Iops
+			actual.RootVolumeTermination = b.Ebs.DeleteOnTermination
 		} else {
 			_, d := BlockDeviceMappingFromAutoscaling(b)
 			actual.BlockDeviceMappings = append(actual.BlockDeviceMappings, d)
@@ -391,7 +394,7 @@ func (t *LaunchConfiguration) buildRootDevice(cloud awsup.AWSCloud) (map[string]
 	bm := make(map[string]*BlockDeviceMapping)
 
 	bm[aws.StringValue(img.RootDeviceName)] = &BlockDeviceMapping{
-		EbsDeleteOnTermination: aws.Bool(true),
+		EbsDeleteOnTermination: t.RootVolumeTermination,
 		EbsVolumeSize:          t.RootVolumeSize,
 		EbsVolumeType:          t.RootVolumeType,
 		EbsVolumeIops:          t.RootVolumeIops,
@@ -495,7 +498,7 @@ func (_ *LaunchConfiguration) RenderTerraform(t *terraform.TerraformTarget, a, e
 					VolumeType:          bdm.EbsVolumeType,
 					VolumeSize:          bdm.EbsVolumeSize,
 					Iops:                bdm.EbsVolumeIops,
-					DeleteOnTermination: fi.Bool(true),
+					DeleteOnTermination: bdm.EbsDeleteOnTermination,
 				}
 			}
 		}
@@ -516,7 +519,7 @@ func (_ *LaunchConfiguration) RenderTerraform(t *terraform.TerraformTarget, a, e
 			for _, deviceName := range sets.StringKeySet(additionalDevices).List() {
 				bdm := additionalDevices[deviceName]
 				tf.EBSBlockDevice = append(tf.EBSBlockDevice, &terraformBlockDevice{
-					DeleteOnTermination: fi.Bool(true),
+					DeleteOnTermination: bdm.EbsDeleteOnTermination,
 					DeviceName:          fi.String(deviceName),
 					Encrypted:           bdm.EbsEncrypted,
 					VolumeSize:          bdm.EbsVolumeSize,
@@ -649,7 +652,7 @@ func (_ *LaunchConfiguration) RenderCloudformation(t *cloudformation.Cloudformat
 						VolumeType:          bdm.EbsVolumeType,
 						VolumeSize:          bdm.EbsVolumeSize,
 						Iops:                bdm.EbsVolumeIops,
-						DeleteOnTermination: fi.Bool(true),
+						DeleteOnTermination: bdm.EbsDeleteOnTermination,
 					},
 				}
 				cf.BlockDeviceMappings = append(cf.BlockDeviceMappings, d)
@@ -672,7 +675,7 @@ func (_ *LaunchConfiguration) RenderCloudformation(t *cloudformation.Cloudformat
 					Ebs: &cloudformationBlockDeviceEBS{
 						VolumeType:          bdm.EbsVolumeType,
 						VolumeSize:          bdm.EbsVolumeSize,
-						DeleteOnTermination: fi.Bool(true),
+						DeleteOnTermination: bdm.EbsDeleteOnTermination,
 						Encrypted:           bdm.EbsEncrypted,
 					},
 				}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Enables to change EBS DeleteOnTermination by specifiying separated flags for *Root Volume* and *Additional Volumes* inside `InstanceGroupSpec`.

**Which issue(s) this PR fixes**:
Fixes #6373

**Special notes for your reviewer**:
I found better to split `retainOnTermination` for Root and Additonal Volumes, as it enabled a deeper customization of InstanceGroups (originally was suggested only a single field in the structure).

Now we can finally close the **1.15** Milestone :smile:   
Also, a huge thanks to @joshbranham's work

**Does this PR introduce a user-facing change?**:
```release-note
Add capacity to retain EBS volumes after instance termination from InstanceGroups
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
---
kind: InstanceGroup
spec:
  rootVolumeRetainOnTermination: true

---
kind: InstanceGroup
spec:
  volumes:
  - device: /dev/xvdd
    retainOnTermination: true
    encrypted: true
    size: 20
    type: gp2
```